### PR TITLE
Created interactive loader for NL Places search

### DIFF
--- a/src/atomicui/atoms/NLLoader/NLLoader.tsx
+++ b/src/atomicui/atoms/NLLoader/NLLoader.tsx
@@ -1,0 +1,48 @@
+/* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. */
+/* SPDX-License-Identifier: MIT-0 */
+
+import React, { useEffect, useState } from "react";
+
+import { Loader as AmplifyLoader, Flex } from "@aws-amplify/ui-react";
+import { useTranslation } from "react-i18next";
+
+interface NLLoaderProps {
+	nlLoadText: string[];
+}
+const NLLoader: React.FC<NLLoaderProps> = ({ nlLoadText }) => {
+	const [loaderIdx, setloaderIdx] = useState(0);
+	const { t } = useTranslation();
+
+	useEffect(() => {
+		let timeout: ReturnType<typeof setTimeout>;
+		if (loaderIdx < nlLoadText.length - 1) {
+			timeout = setTimeout(() => setloaderIdx(loaderIdx + 1), 3500);
+		}
+
+		return () => {
+			clearTimeout(timeout);
+		};
+	}, [nlLoadText, loaderIdx]);
+
+	return (
+		<Flex
+			gap={0}
+			width="100%"
+			height="100%"
+			style={{
+				flexDirection: "column"
+			}}
+		>
+			<Flex
+				style={{
+					fontSize: "12px"
+				}}
+			>
+				<AmplifyLoader size="large" />
+				{t(nlLoadText[loaderIdx] as string)}
+			</Flex>
+		</Flex>
+	);
+};
+
+export default NLLoader;

--- a/src/atomicui/atoms/NLLoader/index.ts
+++ b/src/atomicui/atoms/NLLoader/index.ts
@@ -1,0 +1,4 @@
+/* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. */
+/* SPDX-License-Identifier: MIT-0 */
+
+export { default as NLLoader } from "./NLLoader";

--- a/src/atomicui/atoms/index.ts
+++ b/src/atomicui/atoms/index.ts
@@ -7,3 +7,4 @@ export * from "./Loader";
 export * from "./Logo";
 export * from "./Modal";
 export * from "./DropdownEl";
+export * from "./NLLoader";

--- a/src/atomicui/organisms/SearchBox/SearchBox.tsx
+++ b/src/atomicui/organisms/SearchBox/SearchBox.tsx
@@ -5,6 +5,7 @@ import React, { ChangeEvent, useCallback, useEffect, useMemo, useRef, useState }
 
 import { Autocomplete, Badge, ComboBoxOption, Flex, Placeholder, SwitchField, Text, View } from "@aws-amplify/ui-react";
 import { IconActionMenu, IconClose, IconDirections, IconPin, IconSearch } from "@demo/assets";
+import { NLLoader } from "@demo/atomicui/atoms";
 import { Marker, NotFoundCard, SuggestionMarker } from "@demo/atomicui/molecules";
 import { useAmplifyMap, useAwsPlace } from "@demo/hooks";
 import { DistanceUnitEnum, MapUnitEnum, SuggestionType } from "@demo/types";
@@ -21,6 +22,13 @@ import "./styles.scss";
 
 const { METRIC } = MapUnitEnum;
 const { KILOMETERS, MILES } = DistanceUnitEnum;
+const nlLoadText = [
+	"nl_loader_sample_text_1.text",
+	"nl_loader_sample_text_2.text",
+	"nl_loader_sample_text_3.text",
+	"nl_loader_sample_text_4.text",
+	"nl_loader_sample_text_5.text"
+];
 
 interface SearchBoxProps {
 	mapRef: MapRef | null;
@@ -48,7 +56,7 @@ const SearchBox: React.FC<SearchBoxProps> = ({
 	const timeoutIdRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 	const [value, setValue] = useState<string>("");
 	const [isFocused, setIsFocused] = useState(false);
-	const [isNLChecked, setIsNLChecked] = React.useState(false);
+	const [isNLChecked, setIsNLChecked] = useState(false);
 	const autocompleteRef = useRef<HTMLInputElement | null>(null);
 	const { mapUnit: currentMapUnit, isCurrentLocationDisabled, currentLocationData, viewpoint } = useAmplifyMap();
 	const {
@@ -437,30 +445,44 @@ const SearchBox: React.FC<SearchBoxProps> = ({
 									flex: 1
 								}}
 							>
-								<Flex
-									gap={0}
-									width="100%"
-									height="100%"
-									alignItems="center"
-									style={{
-										borderBottom: isNLChecked && !value ? "1px solid var(--grey-color-3)" : ""
-										// marginLeft: "10px"
-									}}
-								>
-									<SwitchField
-										label={t("nl_search_label.text") as string}
-										labelPosition="end"
-										size="small"
-										isChecked={isNLChecked}
-										onChange={e => setIsNLChecked(e.target.checked)}
+								{isSearching ? (
+									<Flex
+										gap={0}
+										width="100%"
+										height="100%"
+										alignItems="center"
 										style={{
 											marginLeft: "10px"
 										}}
-									/>
-									<Badge size="small" variation="warning">
-										{t("prototype.text") as string}
-									</Badge>
-								</Flex>
+									>
+										<NLLoader nlLoadText={nlLoadText}></NLLoader>
+									</Flex>
+								) : (
+									<Flex
+										gap={0}
+										width="100%"
+										height="100%"
+										alignItems="center"
+										style={{
+											borderBottom: isNLChecked && !value ? "1px solid var(--grey-color-3)" : ""
+											// marginLeft: "10px"
+										}}
+									>
+										<SwitchField
+											label={t("nl_search_label.text") as string}
+											labelPosition="end"
+											size="small"
+											isChecked={isNLChecked}
+											onChange={e => setIsNLChecked(e.target.checked)}
+											style={{
+												marginLeft: "10px"
+											}}
+										/>
+										<Badge size="small" variation="warning">
+											{t("prototype.text") as string}
+										</Badge>
+									</Flex>
+								)}
 								{isNLChecked && !value ? (
 									<Flex
 										gap={0}

--- a/src/locales/en/en.json
+++ b/src/locales/en/en.json
@@ -3574,5 +3574,20 @@
 	},
 	"nl_query_example_3": {
 		"text": "Find me some dinner spots around Vancouver?"
+	},
+	"nl_loader_sample_text_1": {
+		"text": "Buckle up for an adventure! Bedrock on the case."
+	},
+	"nl_loader_sample_text_2": {
+		"text": "Charting your course now! Thanks for waiting."
+	},
+	"nl_loader_sample_text_3": {
+		"text": "Letting Amazon Bedrock navigate this map trip!"
+	},
+	"nl_loader_sample_text_4": {
+		"text": "Consulting the atlas for your location."
+	},
+	"nl_loader_sample_text_5": {
+		"text": "Amazon Bedrock on mapping duty! Searching."
 	}
 }


### PR DESCRIPTION
Added Interactive Loader for NL Places Search feature. This component will act as a loader when a user prompts for a query near the search area. The loader will also display interactive messages to the customer every 3.5 seconds.

# Screenshots
<img width="729" alt="image" src="https://github.com/aws-geospatial/amazon-location-features-demo-web/assets/46388171/7a53a5f2-86a9-40b1-88cc-c93052eb4a25">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
