### PR TITLE
Updated CF templates

### DIFF
--- a/extra/cloudformation/main-cf-template.yaml
+++ b/extra/cloudformation/main-cf-template.yaml
@@ -52,13 +52,11 @@ Resources:
         - amazonlocationdemo://signin/
         - https://location.aws.com/demo
         - http://localhost:3000/demo
-        - https://dev.amazonlocation.services/demo
       LogoutURLs:
         - amazon://signout/
         - amazonlocationdemo://signout/
         - https://location.aws.com/demo?sign_out=true
         - http://localhost:3000/demo?sign_out=true
-        - https://dev.amazonlocation.services/demo?sign_out=true
       AllowedOAuthFlows:
         - implicit
         - code


### PR DESCRIPTION
- removed dev.amazonlocation.services from callback URLs
- E2E test failure is expected due to NL search not yet deployed to prod

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.