### PR TITLE
NL-Search enabled on all data partners

### DIFF
--- a/src/atomicui/organisms/SearchBox/SearchBox.tsx
+++ b/src/atomicui/organisms/SearchBox/SearchBox.tsx
@@ -22,7 +22,7 @@ import BottomSheetHeights from "@demo/core/constants/bottomSheetHeights";
 import { useAmplifyMap, useAwsPlace } from "@demo/hooks";
 import useBottomSheet from "@demo/hooks/useBottomSheet";
 import useDeviceMediaQuery from "@demo/hooks/useDeviceMediaQuery";
-import { DistanceUnitEnum, MapProviderEnum, MapUnitEnum, SuggestionType } from "@demo/types";
+import { DistanceUnitEnum, MapUnitEnum, SuggestionType } from "@demo/types";
 import { AnalyticsEventActionsEnum, ResponsiveUIEnum, TriggeredByEnum } from "@demo/types/Enums";
 import { calculateGeodesicDistance } from "@demo/utils/geoCalculation";
 import { Units } from "@turf/turf";
@@ -86,7 +86,6 @@ const SearchBox: React.FC<SearchBoxProps> = ({
 	const [isNLChecked, setIsNLChecked] = useState(false);
 	const autocompleteRef = useRef<HTMLInputElement | null>(null);
 	const { mapUnit: currentMapUnit, isCurrentLocationDisabled, currentLocationData, viewpoint } = useAmplifyMap();
-	const { mapProvider: currentMapProvider } = useAmplifyMap();
 	const {
 		clusters,
 		suggestions,
@@ -751,7 +750,7 @@ const SearchBox: React.FC<SearchBoxProps> = ({
 									}
 									crossOrigin={undefined}
 								/>
-								{NL_BASE_URL && NL_API_KEY && currentMapProvider === MapProviderEnum.ESRI ? (
+								{NL_BASE_URL && NL_API_KEY ? (
 									<Flex
 										className="nl-search-container"
 										id="nl-search"

--- a/src/atomicui/organisms/SearchBox/SearchBox.tsx
+++ b/src/atomicui/organisms/SearchBox/SearchBox.tsx
@@ -22,7 +22,7 @@ import BottomSheetHeights from "@demo/core/constants/bottomSheetHeights";
 import { useAmplifyMap, useAwsPlace } from "@demo/hooks";
 import useBottomSheet from "@demo/hooks/useBottomSheet";
 import useDeviceMediaQuery from "@demo/hooks/useDeviceMediaQuery";
-import { DistanceUnitEnum, MapUnitEnum, SuggestionType } from "@demo/types";
+import { DistanceUnitEnum, MapProviderEnum, MapUnitEnum, SuggestionType } from "@demo/types";
 import { AnalyticsEventActionsEnum, ResponsiveUIEnum, TriggeredByEnum } from "@demo/types/Enums";
 import { calculateGeodesicDistance } from "@demo/utils/geoCalculation";
 import { Units } from "@turf/turf";
@@ -86,6 +86,7 @@ const SearchBox: React.FC<SearchBoxProps> = ({
 	const [isNLChecked, setIsNLChecked] = useState(false);
 	const autocompleteRef = useRef<HTMLInputElement | null>(null);
 	const { mapUnit: currentMapUnit, isCurrentLocationDisabled, currentLocationData, viewpoint } = useAmplifyMap();
+	const { mapProvider: currentMapProvider } = useAmplifyMap();
 	const {
 		clusters,
 		suggestions,
@@ -750,7 +751,7 @@ const SearchBox: React.FC<SearchBoxProps> = ({
 									}
 									crossOrigin={undefined}
 								/>
-								{NL_BASE_URL && NL_API_KEY ? (
+								{NL_BASE_URL && NL_API_KEY && currentMapProvider !== MapProviderEnum.GRAB ? (
 									<Flex
 										className="nl-search-container"
 										id="nl-search"

--- a/src/services/useAwsPlaceService.ts
+++ b/src/services/useAwsPlaceService.ts
@@ -87,12 +87,14 @@ const useAwsPlaceService = () => {
 			},
 			getNLPlacesByText: async (Text: string) => {
 				const BiasPosition = [viewpoint?.longitude as number, viewpoint?.latitude as number];
+				const mapProvider = currentMapProvider === MapProviderEnum.HERE ? "Here" : currentMapProvider;
 				const response = await fetch(
 					`${NL_BASE_URL}/places/ask?` +
 						new URLSearchParams([
 							["Text", Text],
 							["BiasPosition", BiasPosition[0].toString()],
-							["BiasPosition", BiasPosition[1].toString()]
+							["BiasPosition", BiasPosition[1].toString()],
+							["DataSource", mapProvider]
 						]),
 					{
 						method: "GET",


### PR DESCRIPTION
This PR allows NL search to be enabled on all data providers (Esri, Here, Grab, OpenData).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
