### PR TITLE
disable Here and Grab in nl_search

### DIFF
--- a/src/atomicui/organisms/SearchBox/SearchBox.tsx
+++ b/src/atomicui/organisms/SearchBox/SearchBox.tsx
@@ -156,6 +156,12 @@ const SearchBox: React.FC<SearchBoxProps> = ({
 		}
 	}, [ui, isDesktop, bottomSheetRef, setBottomSheetMinHeight]);
 
+	useEffect(() => {
+		if (currentMapProvider === MapProviderEnum.GRAB || currentMapProvider === MapProviderEnum.HERE) {
+			setIsNLChecked(false);
+		}
+	}, [isNLChecked, currentMapProvider]);
+
 	const handleSearch = useCallback(
 		async (value: string, exact = false, action: string) => {
 			setSearchingState(!!value?.length);
@@ -751,7 +757,10 @@ const SearchBox: React.FC<SearchBoxProps> = ({
 									}
 									crossOrigin={undefined}
 								/>
-								{NL_BASE_URL && NL_API_KEY && currentMapProvider !== MapProviderEnum.GRAB ? (
+								{NL_BASE_URL &&
+								NL_API_KEY &&
+								currentMapProvider !== MapProviderEnum.GRAB &&
+								currentMapProvider !== MapProviderEnum.HERE ? (
 									<Flex
 										className="nl-search-container"
 										id="nl-search"


### PR DESCRIPTION
This PR disables NL-Search in Esri and Here due to Here not being able to work with nl-search.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
