### PR TITLE
feedback remove nl search category

### DIFF
--- a/src/atomicui/molecules/FeedbackModal/FeedbackModal.tsx
+++ b/src/atomicui/molecules/FeedbackModal/FeedbackModal.tsx
@@ -17,7 +17,6 @@ import "./styles.scss";
 const feedbackCategories = [
 	{ id: "General", label: "General" },
 	{ id: "Places", label: "Places" },
-	{ id: "NaturalLanguageSearch", label: "Natural Language Search" },
 	{ id: "Maps", label: "Maps" },
 	{ id: "Routes", label: "Routes" },
 	{ id: "TrackingGeofencing", label: "Tracking & Geofencing" }


### PR DESCRIPTION
This PR removes the NL Language Search category from the Feedback form.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
