### PR TITLE
[ALS-1854] Node version updated for lambdas

### DIFF
--- a/extra/cloudformation/default-unauth-resources-template.yaml
+++ b/extra/cloudformation/default-unauth-resources-template.yaml
@@ -647,7 +647,7 @@ Resources:
     Properties:
       FunctionName: AmazonLocationDemoIotEndpointProvider
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       Timeout: 30
       Role: !GetAtt AmazonLocationLambdaExecutionRole.Arn
       Code:
@@ -801,7 +801,7 @@ Resources:
       FunctionName: AmazonLocationDemoIoTPublisher
       Handler: index.handler
       Role: !GetAtt [AmazonLocationLambdaExecutionRole, Arn]
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       Timeout: 30
 
   AmazonLocationLambdaExecutionRole:

--- a/extra/cloudformation/main-cf-template.yaml
+++ b/extra/cloudformation/main-cf-template.yaml
@@ -506,7 +506,7 @@ Resources:
     Properties:
       FunctionName: AmazonLocationDemoIotEndpointProvider
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       Timeout: 30
       Role: !GetAtt AmazonLocationLambdaExecutionRole.Arn
       Code:
@@ -649,7 +649,7 @@ Resources:
       FunctionName: AmazonLocationDemoIoTPublisher
       Handler: index.handler
       Role: !GetAtt [AmazonLocationLambdaExecutionRole, Arn]
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       Timeout: 30
   AmazonLocationLambdaExecutionRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
This PR updates the node version to 20 used by lambdas in the default and main CloudFormation templates.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
