### PR TITLE
Override cookie nested dependency version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22060,9 +22060,9 @@
 			}
 		},
 		"node_modules/cookie": {
-			"version": "0.4.2",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-			"integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+			"integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
@@ -25648,16 +25648,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/express"
-			}
-		},
-		"node_modules/express/node_modules/cookie": {
-			"version": "0.7.1",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
-			"integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
 			}
 		},
 		"node_modules/express/node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
 		"ava": "^3.0.0",
 		"axios": "^0.28.0",
 		"braces": "^3.0.3",
+		"cookie": "^0.7.2",
 		"@cypress/request": "^3.0.0",
 		"fast-xml-parser": "^4.1.2",
 		"got": "^11.8.5",


### PR DESCRIPTION
## Description
This resolves the [security vulnerability ](https://github.com/aws-geospatial/amazon-location-features-demo-web/security/dependabot/94) in the nested dependency of the `cookie` package. The dependabot attempt to resolve this https://github.com/aws-geospatial/amazon-location-features-demo-web/pull/273 attempted to update to the latest versions of `@aws-amplify/ui-react` and `aws-amplify` that consume `cookie`, but unfortunately the versions needed for those dependencies required updating to a several major-versions newer package, which would've required an extensive refactor/re-write of our usage of `@aws-amplify/ui-react`.

I was able to override the `cookie` nested dependency to the latest version that was still compatible with the version the amplify dependencies needed (`< 1.0`), and this has resolved all security vulnerabilities in `amazon-location-features-demo-web` now.

Once we merge this, we will also be able to update https://github.com/aws-geospatial/amazon-location-web-marketing to use this new version, which will clear up all remaining (4) security vulnerabilities in its repo as well:

https://github.com/aws-geospatial/amazon-location-web-marketing/security/dependabot