### PR TITLE
[ALS-2051] Remove go button

### DIFF
--- a/src/atomicui/organisms/RouteBox/RouteBox.tsx
+++ b/src/atomicui/organisms/RouteBox/RouteBox.tsx
@@ -1465,16 +1465,6 @@ const RouteBox: FC<RouteBoxProps> = ({
 								</View>
 
 								<Flex grow={1} />
-
-								{isUserDeviceIsAndroid() === ANDROID && (
-									<Button
-										variation="primary"
-										className="go-button bold"
-										onClick={() => window.open(GOOGLE_PLAY_STORE_LINK, "_blank")}
-									>
-										{t("go.text")}
-									</Button>
-								)}
 							</View>
 							{renderSteps}
 						</View>


### PR DESCRIPTION
This PR removed "GO" button from responsive routes screen.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
