### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,4 +1,6 @@
 name: E2E tests
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/aws-geospatial/amazon-location-features-demo-web/security/code-scanning/1](https://github.com/aws-geospatial/amazon-location-features-demo-web/security/code-scanning/1)

To fix this problem, add a `permissions` key to the workflow file, either at the root level (recommended for single-job workflows like this one) or at the job level. The permissions should be set for the GITHUB_TOKEN to provide only the access necessary for the workflow to run. For typical E2E test jobs that check out code and upload reports, it's often sufficient to grant `contents: read` for code checkout and `actions: write` for uploading artifacts. However, since the workflow only checks out code, runs tests, and uploads artifacts, `contents: read` will suffice unless a step requires write access to actions or other scopes. The minimal starting point per CodeQL is `contents: read`.

Therefore, edit `.github/workflows/e2e-tests.yml` and add the following block after the workflow `name` and before `on:`:

```yaml
permissions:
  contents: read
```

This change will limit the GITHUB_TOKEN's permissions to read-only for repository contents, following the principle of least privilege and GitHub's recommendations.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
