### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -8,6 +8,8 @@ jobs:
   unit-tests:
     name: Unit tests
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Potential fix for [https://github.com/aws-geospatial/amazon-location-features-demo-web/security/code-scanning/2](https://github.com/aws-geospatial/amazon-location-features-demo-web/security/code-scanning/2)

To fix this issue, you should add a `permissions` block to your workflow or job to restrict the `GITHUB_TOKEN` to the minimal permissions required. For a unit test job that does not interact with repository resources beyond checking out code, the minimal required permission is generally `contents: read`. This can be set at the job level to affect only the `unit-tests` job (which is the only job in this workflow), or at the workflow root to affect all jobs. The best way is to set:

```yml
    permissions:
      contents: read
```

inside your job definition (between `runs-on` and `steps`), or at the top of the workflow (after `name:` and before `on:`).

Since you have only one job, both approaches are equivalent in result; for clarity and explicitness related to the CodeQL finding (which flags the job), set it at the job level.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
