### PR TITLE
Potential fix for code scanning alert no. 3: Insecure randomness

### DIFF
--- a/src/utils/uuid.ts
+++ b/src/utils/uuid.ts
@@ -3,14 +3,27 @@
 
 const uuid = {
 	randomUUID: function () {
-		const {
-			crypto: { randomUUID }
-		} = self;
+		const cryptoObj = (typeof self !== "undefined" && self.crypto) ? self.crypto : (typeof window !== "undefined" && window.crypto) ? window.crypto : undefined;
 
-		if (typeof randomUUID !== "undefined") {
-			return self.crypto.randomUUID();
+		if (cryptoObj && typeof cryptoObj.randomUUID === "function") {
+			return cryptoObj.randomUUID();
+		} else if (cryptoObj && typeof cryptoObj.getRandomValues === "function") {
+			// generate a RFC4122 version 4 UUID using getRandomValues
+			const bytes = new Uint8Array(16);
+			cryptoObj.getRandomValues(bytes);
+			// Set version bits (4) and reserved bits per RFC4122 (variant 1)
+			bytes[6] = (bytes[6] & 0x0f) | 0x40;
+			bytes[8] = (bytes[8] & 0x3f) | 0x80;
+			const hex = Array.from(bytes, b => b.toString(16).padStart(2, "0"));
+			return (
+				hex.slice(0, 4).join("") + "-" +
+				hex.slice(4, 6).join("") + "-" +
+				hex.slice(6, 8).join("") + "-" +
+				hex.slice(8, 10).join("") + "-" +
+				hex.slice(10, 16).join("")
+			);
 		} else {
-			return Date.now().toString(36) + Math.random().toString(36).substring(2);
+			throw new Error("No cryptographically secure random number generator available.");
 		}
 	},
 	validateUUID: function (uuid: string) {


### PR DESCRIPTION
Potential fix for [https://github.com/aws-geospatial/amazon-location-features-demo-web/security/code-scanning/3](https://github.com/aws-geospatial/amazon-location-features-demo-web/security/code-scanning/3)

To fix this problem, we should ensure the fallback code in `uuid.randomUUID()` never uses `Math.random()` for security-sensitive identifier generation. Instead, when `crypto.randomUUID()` is not available, the fallback must use `crypto.getRandomValues()` to generate random bytes, format them accordingly (for example as a RFC4122-compliant UUID, or at least a strong random string). We must update the existing fallback (line 13 in `src/utils/uuid.ts`) to use `crypto.getRandomValues()`, which is widely supported, rather than `Math.random()`. If neither method is available, we could consider throwing an error, but for most browser environments, `getRandomValues()` suffices. Only `src/utils/uuid.ts` requires modification.

#### Changes to make
- Replace the insecure fallback in `uuid.randomUUID()` to generate a cryptographically strong random identifier using `crypto.getRandomValues()` (e.g., generate 16 bytes and encode as hex or Base64).
- If the environment does not support crypto APIs at all, optionally throw an error.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
