### PR TITLE
Remove unused vite-plugin-node-polyfills to fix elliptic vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -81,7 +81,6 @@
 				"vite-plugin-dts": "^4.5.4",
 				"vite-plugin-eslint2": "^5.0.5",
 				"vite-plugin-inspect": "^0.8.1",
-				"vite-plugin-node-polyfills": "^0.25.0",
 				"vite-plugin-svgr": "^5.2.0",
 				"vitest": "^4.1.8"
 			},
@@ -4366,28 +4365,6 @@
 			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
 			"integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
 			"dev": true
-		},
-		"node_modules/@rollup/plugin-inject": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/@rollup/plugin-inject/-/plugin-inject-5.0.5.tgz",
-			"integrity": "sha512-2+DEJbNBoPROPkgTDNe8/1YXWcqxbN5DTjASVIOx8HS+pITXushyNiBV56RB08zuptzz8gT3YfkqriTBVycepg==",
-			"dev": true,
-			"dependencies": {
-				"@rollup/pluginutils": "^5.0.1",
-				"estree-walker": "^2.0.2",
-				"magic-string": "^0.30.3"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			},
-			"peerDependencies": {
-				"rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
-			},
-			"peerDependenciesMeta": {
-				"rollup": {
-					"optional": true
-				}
-			}
 		},
 		"node_modules/@rollup/pluginutils": {
 			"version": "5.3.0",
@@ -9095,37 +9072,6 @@
 				"safer-buffer": "~2.1.0"
 			}
 		},
-		"node_modules/asn1.js": {
-			"version": "4.10.1",
-			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
-			"integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
-			"dev": true,
-			"dependencies": {
-				"bn.js": "^4.0.0",
-				"inherits": "^2.0.1",
-				"minimalistic-assert": "^1.0.0"
-			}
-		},
-		"node_modules/asn1.js/node_modules/bn.js": {
-			"version": "4.12.3",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
-			"integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/assert": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
-			"integrity": "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==",
-			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.2",
-				"is-nan": "^1.3.2",
-				"object-is": "^1.1.5",
-				"object.assign": "^4.1.4",
-				"util": "^0.12.5"
-			}
-		},
 		"node_modules/assert-plus": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
@@ -9692,13 +9638,6 @@
 			"integrity": "sha512-DRQrD6gJyy8FbiE4s+bDoXS9hiW3Vbx5uCdwvcCf3zLHL+Iv7LtGHLpr+GZV8rHG8tK766FGYBwRbu8pELTt+w==",
 			"dev": true
 		},
-		"node_modules/bn.js": {
-			"version": "5.2.3",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.3.tgz",
-			"integrity": "sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/body-scroll-lock": {
 			"version": "3.1.5",
 			"resolved": "https://registry.npmjs.org/body-scroll-lock/-/body-scroll-lock-3.1.5.tgz",
@@ -9781,102 +9720,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/brorand": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-			"integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
-			"dev": true
-		},
-		"node_modules/browser-resolve": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-2.0.0.tgz",
-			"integrity": "sha512-7sWsQlYL2rGLy2IWm8WL8DCTJvYLc/qlOnsakDac87SOoCd16WLsaAMdCiAqsTNHIe+SXfaqyxyo6THoWqs8WQ==",
-			"dev": true,
-			"dependencies": {
-				"resolve": "^1.17.0"
-			}
-		},
-		"node_modules/browserify-aes": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
-			"integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
-			"dev": true,
-			"dependencies": {
-				"buffer-xor": "^1.0.3",
-				"cipher-base": "^1.0.0",
-				"create-hash": "^1.1.0",
-				"evp_bytestokey": "^1.0.3",
-				"inherits": "^2.0.1",
-				"safe-buffer": "^5.0.1"
-			}
-		},
-		"node_modules/browserify-cipher": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
-			"integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
-			"dev": true,
-			"dependencies": {
-				"browserify-aes": "^1.0.4",
-				"browserify-des": "^1.0.0",
-				"evp_bytestokey": "^1.0.0"
-			}
-		},
-		"node_modules/browserify-des": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
-			"integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
-			"dev": true,
-			"dependencies": {
-				"cipher-base": "^1.0.1",
-				"des.js": "^1.0.0",
-				"inherits": "^2.0.1",
-				"safe-buffer": "^5.1.2"
-			}
-		},
-		"node_modules/browserify-rsa": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.1.tgz",
-			"integrity": "sha512-YBjSAiTqM04ZVei6sXighu679a3SqWORA3qZTEqZImnlkDIFtKc6pNutpjyZ8RJTjQtuYfeetkxM11GwoYXMIQ==",
-			"dev": true,
-			"dependencies": {
-				"bn.js": "^5.2.1",
-				"randombytes": "^2.1.0",
-				"safe-buffer": "^5.2.1"
-			},
-			"engines": {
-				"node": ">= 0.10"
-			}
-		},
-		"node_modules/browserify-sign": {
-			"version": "4.2.6",
-			"resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.6.tgz",
-			"integrity": "sha512-sd+Q65fjlWCYWtZKXiKfrUc8d+4jtp/8f0W2NkwzLtoW4bI6UDnWusLWIurHnmurW0XShIRxpwiOX4EoPtXUAg==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"bn.js": "^5.2.3",
-				"browserify-rsa": "^4.1.1",
-				"create-hash": "^1.2.0",
-				"create-hmac": "^1.1.7",
-				"elliptic": "^6.6.1",
-				"inherits": "^2.0.4",
-				"parse-asn1": "^5.1.9",
-				"readable-stream": "^2.3.8",
-				"safe-buffer": "^5.2.1"
-			},
-			"engines": {
-				"node": ">= 0.10"
-			}
-		},
-		"node_modules/browserify-zlib": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
-			"integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
-			"dev": true,
-			"dependencies": {
-				"pako": "~1.0.5"
-			}
-		},
 		"node_modules/browserslist": {
 			"version": "4.28.4",
 			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
@@ -9926,18 +9769,6 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
 			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
-		},
-		"node_modules/buffer-xor": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
-			"integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
-			"dev": true
-		},
-		"node_modules/builtin-status-codes": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
-			"integrity": "sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ==",
-			"dev": true
 		},
 		"node_modules/bundle-name": {
 			"version": "4.1.0",
@@ -10183,19 +10014,6 @@
 			"resolved": "https://registry.npmjs.org/ci-parallel-vars/-/ci-parallel-vars-1.0.1.tgz",
 			"integrity": "sha512-uvzpYrpmidaoxvIQHM+rKSrigjOe9feHYbw4uOI2gdfe1C3xIlxO+kVXq83WQWNniTf8bAxVpy+cQeFQsMERKg==",
 			"dev": true
-		},
-		"node_modules/cipher-base": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.6.tgz",
-			"integrity": "sha512-3Ek9H3X6pj5TgenXYtNWdaBon1tgYCaebd+XPg0keyjEbEfkD4KkmAxkQ/i1vYvxdcT5nscLBfq9VJRmCBcFSw==",
-			"dev": true,
-			"dependencies": {
-				"inherits": "^2.0.4",
-				"safe-buffer": "^5.2.1"
-			},
-			"engines": {
-				"node": ">= 0.10"
-			}
 		},
 		"node_modules/classnames": {
 			"version": "2.5.1",
@@ -10552,18 +10370,6 @@
 				"typedarray-to-buffer": "^3.1.5"
 			}
 		},
-		"node_modules/console-browserify": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
-			"integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==",
-			"dev": true
-		},
-		"node_modules/constants-browserify": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
-			"integrity": "sha512-xFxOwqIzR/e1k1gLiWEophSCMqXcwVHIH7akf7b/vxcUeGunlj3hvZaaqxwHsTgn+IndtkQJgSztIDWeumWJDQ==",
-			"dev": true
-		},
 		"node_modules/convert-source-map": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -10621,56 +10427,6 @@
 				"node": ">=0.8"
 			}
 		},
-		"node_modules/create-ecdh": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
-			"integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
-			"dev": true,
-			"dependencies": {
-				"bn.js": "^4.1.0",
-				"elliptic": "^6.5.3"
-			}
-		},
-		"node_modules/create-ecdh/node_modules/bn.js": {
-			"version": "4.12.3",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
-			"integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/create-hash": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
-			"integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
-			"dev": true,
-			"dependencies": {
-				"cipher-base": "^1.0.1",
-				"inherits": "^2.0.1",
-				"md5.js": "^1.3.4",
-				"ripemd160": "^2.0.1",
-				"sha.js": "^2.4.0"
-			}
-		},
-		"node_modules/create-hmac": {
-			"version": "1.1.7",
-			"resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
-			"integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
-			"dev": true,
-			"dependencies": {
-				"cipher-base": "^1.0.3",
-				"create-hash": "^1.1.0",
-				"inherits": "^2.0.1",
-				"ripemd160": "^2.0.0",
-				"safe-buffer": "^5.0.1",
-				"sha.js": "^2.4.8"
-			}
-		},
-		"node_modules/create-require": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-			"dev": true
-		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.6",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -10683,32 +10439,6 @@
 			},
 			"engines": {
 				"node": ">= 8"
-			}
-		},
-		"node_modules/crypto-browserify": {
-			"version": "3.12.1",
-			"resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.1.tgz",
-			"integrity": "sha512-r4ESw/IlusD17lgQi1O20Fa3qNnsckR126TdUuBgAu7GBYSIPvdNyONd3Zrxh0xCwA4+6w/TDArBPsMvhur+KQ==",
-			"dev": true,
-			"dependencies": {
-				"browserify-cipher": "^1.0.1",
-				"browserify-sign": "^4.2.3",
-				"create-ecdh": "^4.0.4",
-				"create-hash": "^1.2.0",
-				"create-hmac": "^1.1.7",
-				"diffie-hellman": "^5.0.3",
-				"hash-base": "~3.0.4",
-				"inherits": "^2.0.4",
-				"pbkdf2": "^3.1.2",
-				"public-encrypt": "^4.0.3",
-				"randombytes": "^2.1.0",
-				"randomfill": "^1.0.4"
-			},
-			"engines": {
-				"node": ">= 0.10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/crypto-js": {
@@ -11378,16 +11108,6 @@
 			"resolved": "https://registry.npmjs.org/density-clustering/-/density-clustering-1.3.0.tgz",
 			"integrity": "sha512-icpmBubVTwLnsaor9qH/4tG5+7+f61VcqMN3V3pm9sxxSCt2Jcs0zWOgwZW9ARJYaKD3FumIgHiMOcIMRRAzFQ=="
 		},
-		"node_modules/des.js": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz",
-			"integrity": "sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==",
-			"dev": true,
-			"dependencies": {
-				"inherits": "^2.0.1",
-				"minimalistic-assert": "^1.0.0"
-			}
-		},
 		"node_modules/detect-indent": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-0.1.4.tgz",
@@ -11425,24 +11145,6 @@
 				"node": ">=0.3.1"
 			}
 		},
-		"node_modules/diffie-hellman": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
-			"integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
-			"dev": true,
-			"dependencies": {
-				"bn.js": "^4.1.0",
-				"miller-rabin": "^4.0.0",
-				"randombytes": "^2.0.0"
-			}
-		},
-		"node_modules/diffie-hellman/node_modules/bn.js": {
-			"version": "4.12.3",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
-			"integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/dijkstrajs": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
@@ -11465,18 +11167,6 @@
 			"resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
 			"integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
 			"dev": true
-		},
-		"node_modules/domain-browser": {
-			"version": "4.22.0",
-			"resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.22.0.tgz",
-			"integrity": "sha512-IGBwjF7tNk3cwypFNH/7bfzBcgSCbaMOD3GsaY1AU/JRrnHnYgEM0+9kQt52iZxjNsjBtJYtao146V+f8jFZNw==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://bevry.me/fund"
-			}
 		},
 		"node_modules/dot-case": {
 			"version": "3.0.4",
@@ -11617,28 +11307,6 @@
 			"integrity": "sha512-I2484/KkAvl8lm9VyjH2JnbOIV0d/UCqT7gbzs6l+o6Vmn9wgB66uVcKX+Vk6HrXtY6fbWTOEXuv8waDTuFNCw==",
 			"dev": true,
 			"license": "ISC"
-		},
-		"node_modules/elliptic": {
-			"version": "6.6.1",
-			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
-			"integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
-			"dev": true,
-			"dependencies": {
-				"bn.js": "^4.11.9",
-				"brorand": "^1.1.0",
-				"hash.js": "^1.0.0",
-				"hmac-drbg": "^1.0.1",
-				"inherits": "^2.0.4",
-				"minimalistic-assert": "^1.0.1",
-				"minimalistic-crypto-utils": "^1.0.1"
-			}
-		},
-		"node_modules/elliptic/node_modules/bn.js": {
-			"version": "4.12.3",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
-			"integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/emittery": {
 			"version": "0.8.1",
@@ -12554,25 +12222,6 @@
 			"integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/events": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-			"integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.8.x"
-			}
-		},
-		"node_modules/evp_bytestokey": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
-			"integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
-			"dev": true,
-			"dependencies": {
-				"md5.js": "^1.3.4",
-				"safe-buffer": "^5.1.1"
-			}
 		},
 		"node_modules/execa": {
 			"version": "4.1.0",
@@ -13575,29 +13224,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/hash-base": {
-			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.5.tgz",
-			"integrity": "sha512-vXm0l45VbcHEVlTCzs8M+s0VeYsB2lnlAaThoLKGXr3bE/VWDOelNUnycUPEhKEaXARL2TEFjBOyUiM6+55KBg==",
-			"dev": true,
-			"dependencies": {
-				"inherits": "^2.0.4",
-				"safe-buffer": "^5.2.1"
-			},
-			"engines": {
-				"node": ">= 0.10"
-			}
-		},
-		"node_modules/hash.js": {
-			"version": "1.1.7",
-			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
-			"integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
-			"dev": true,
-			"dependencies": {
-				"inherits": "^2.0.3",
-				"minimalistic-assert": "^1.0.1"
-			}
-		},
 		"node_modules/hasha": {
 			"version": "5.2.2",
 			"resolved": "https://registry.npmjs.org/hasha/-/hasha-5.2.2.tgz",
@@ -13686,17 +13312,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"hermes-estree": "0.25.1"
-			}
-		},
-		"node_modules/hmac-drbg": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
-			"integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
-			"dev": true,
-			"dependencies": {
-				"hash.js": "^1.0.3",
-				"minimalistic-assert": "^1.0.0",
-				"minimalistic-crypto-utils": "^1.0.1"
 			}
 		},
 		"node_modules/hosted-git-info": {
@@ -13818,12 +13433,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
-		},
-		"node_modules/https-browserify": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
-			"integrity": "sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg==",
-			"dev": true
 		},
 		"node_modules/https-proxy-agent": {
 			"version": "7.0.6",
@@ -14378,22 +13987,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/is-nan": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
-			"integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
-			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.0",
-				"define-properties": "^1.1.3"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/is-negative-zero": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
@@ -14703,15 +14296,6 @@
 			"integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/isomorphic-timers-promises": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/isomorphic-timers-promises/-/isomorphic-timers-promises-1.0.1.tgz",
-			"integrity": "sha512-u4sej9B1LPSxTGKB/HiuzvEQnXH0ECYkSVQU39koSwmFAxhlEAFl9RdTvLv4TOTQUgBS5O3O5fwUxk6byBZ+IQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/isomorphic-ws": {
@@ -16123,17 +15707,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/md5.js": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
-			"integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
-			"dev": true,
-			"dependencies": {
-				"hash-base": "^3.0.0",
-				"inherits": "^2.0.1",
-				"safe-buffer": "^5.1.2"
-			}
-		},
 		"node_modules/mem": {
 			"version": "8.1.1",
 			"resolved": "https://registry.npmjs.org/mem/-/mem-8.1.1.tgz",
@@ -16238,26 +15811,6 @@
 				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
-		"node_modules/miller-rabin": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
-			"integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
-			"dev": true,
-			"dependencies": {
-				"bn.js": "^4.0.0",
-				"brorand": "^1.0.1"
-			},
-			"bin": {
-				"miller-rabin": "bin/miller-rabin"
-			}
-		},
-		"node_modules/miller-rabin/node_modules/bn.js": {
-			"version": "4.12.3",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
-			"integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/mime-db": {
 			"version": "1.52.0",
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -16316,18 +15869,6 @@
 			"engines": {
 				"node": ">=4"
 			}
-		},
-		"node_modules/minimalistic-assert": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-			"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
-			"dev": true
-		},
-		"node_modules/minimalistic-crypto-utils": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-			"integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
-			"dev": true
 		},
 		"node_modules/minimatch": {
 			"version": "3.1.4",
@@ -16796,100 +16337,6 @@
 				"node": ">=18"
 			}
 		},
-		"node_modules/node-stdlib-browser": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/node-stdlib-browser/-/node-stdlib-browser-1.3.1.tgz",
-			"integrity": "sha512-X75ZN8DCLftGM5iKwoYLA3rjnrAEs97MkzvSd4q2746Tgpg8b8XWiBGiBG4ZpgcAqBgtgPHTiAc8ZMCvZuikDw==",
-			"dev": true,
-			"dependencies": {
-				"assert": "^2.0.0",
-				"browser-resolve": "^2.0.0",
-				"browserify-zlib": "^0.2.0",
-				"buffer": "^5.7.1",
-				"console-browserify": "^1.1.0",
-				"constants-browserify": "^1.0.0",
-				"create-require": "^1.1.1",
-				"crypto-browserify": "^3.12.1",
-				"domain-browser": "4.22.0",
-				"events": "^3.0.0",
-				"https-browserify": "^1.0.0",
-				"isomorphic-timers-promises": "^1.0.1",
-				"os-browserify": "^0.3.0",
-				"path-browserify": "^1.0.1",
-				"pkg-dir": "^5.0.0",
-				"process": "^0.11.10",
-				"punycode": "^1.4.1",
-				"querystring-es3": "^0.2.1",
-				"readable-stream": "^3.6.0",
-				"stream-browserify": "^3.0.0",
-				"stream-http": "^3.2.0",
-				"string_decoder": "^1.0.0",
-				"timers-browserify": "^2.0.4",
-				"tty-browserify": "0.0.1",
-				"url": "^0.11.4",
-				"util": "^0.12.4",
-				"vm-browserify": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/node-stdlib-browser/node_modules/buffer": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-			"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"dependencies": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.1.13"
-			}
-		},
-		"node_modules/node-stdlib-browser/node_modules/pkg-dir": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
-			"integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
-			"dev": true,
-			"dependencies": {
-				"find-up": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/node-stdlib-browser/node_modules/punycode": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-			"integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
-			"dev": true
-		},
-		"node_modules/node-stdlib-browser/node_modules/readable-stream": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-			"dev": true,
-			"dependencies": {
-				"inherits": "^2.0.3",
-				"string_decoder": "^1.1.1",
-				"util-deprecate": "^1.0.1"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
 		"node_modules/normalize-package-data": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
@@ -17199,12 +16646,6 @@
 				"url": "https://github.com/chalk/chalk?sponsor=1"
 			}
 		},
-		"node_modules/os-browserify": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
-			"integrity": "sha512-gjcpUc3clBf9+210TRaDWbf+rZZZEshZ+DlXMRCeAjp0xhTrnQsKHypIy1J3d5hKdUzj69t708EHtU8P6bUn0A==",
-			"dev": true
-		},
 		"node_modules/ospath": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/ospath/-/ospath-1.2.2.tgz",
@@ -17350,12 +16791,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/pako": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-			"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-			"dev": true
-		},
 		"node_modules/parent-module": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -17366,23 +16801,6 @@
 			},
 			"engines": {
 				"node": ">=6"
-			}
-		},
-		"node_modules/parse-asn1": {
-			"version": "5.1.9",
-			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.9.tgz",
-			"integrity": "sha512-fIYNuZ/HastSb80baGOuPRo1O9cf4baWw5WsAp7dBuUzeTD/BoaG8sVTdlPFksBE2lF21dN+A1AnrpIjSWqHHg==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"asn1.js": "^4.10.1",
-				"browserify-aes": "^1.2.0",
-				"evp_bytestokey": "^1.0.3",
-				"pbkdf2": "^3.1.5",
-				"safe-buffer": "^5.2.1"
-			},
-			"engines": {
-				"node": ">= 0.10"
 			}
 		},
 		"node_modules/parse-json": {
@@ -17501,24 +16919,6 @@
 			},
 			"bin": {
 				"pbf": "bin/pbf"
-			}
-		},
-		"node_modules/pbkdf2": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.5.tgz",
-			"integrity": "sha512-Q3CG/cYvCO1ye4QKkuH7EXxs3VC/rI1/trd+qX2+PolbaKG0H+bgcZzrTt96mMyRtejk+JMCiLUn3y29W8qmFQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"create-hash": "^1.2.0",
-				"create-hmac": "^1.1.7",
-				"ripemd160": "^2.0.3",
-				"safe-buffer": "^5.2.1",
-				"sha.js": "^2.4.12",
-				"to-buffer": "^1.2.1"
-			},
-			"engines": {
-				"node": ">= 0.10"
 			}
 		},
 		"node_modules/pend": {
@@ -17994,27 +17394,6 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/public-encrypt": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
-			"integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
-			"dev": true,
-			"dependencies": {
-				"bn.js": "^4.1.0",
-				"browserify-rsa": "^4.0.0",
-				"create-hash": "^1.1.0",
-				"parse-asn1": "^5.0.0",
-				"randombytes": "^2.0.1",
-				"safe-buffer": "^5.1.2"
-			}
-		},
-		"node_modules/public-encrypt/node_modules/bn.js": {
-			"version": "4.12.3",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
-			"integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/pump": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
@@ -18096,15 +17475,6 @@
 			],
 			"license": "MIT"
 		},
-		"node_modules/querystring-es3": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
-			"integrity": "sha512-773xhDQnZBMFobEiztv8LIl70ch5MSF/jUQVlhwFyBILqq96anmoctVIYz+ZRp0qbCKATTn6ev02M3r7Ga5vqA==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.4.x"
-			}
-		},
 		"node_modules/queue-microtask": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -18146,25 +17516,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/ramda"
-			}
-		},
-		"node_modules/randombytes": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-			"dev": true,
-			"dependencies": {
-				"safe-buffer": "^5.1.0"
-			}
-		},
-		"node_modules/randomfill": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
-			"integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
-			"dev": true,
-			"dependencies": {
-				"randombytes": "^2.0.5",
-				"safe-buffer": "^5.1.0"
 			}
 		},
 		"node_modules/rbush": {
@@ -18931,36 +18282,6 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"node_modules/ripemd160": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.3.tgz",
-			"integrity": "sha512-5Di9UC0+8h1L6ZD2d7awM7E/T4uA1fJRlx6zk/NvdCCVEoAnFqvHmCuNeIKoCeIixBX/q8uM+6ycDvF8woqosA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"hash-base": "^3.1.2",
-				"inherits": "^2.0.4"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
-		"node_modules/ripemd160/node_modules/hash-base": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.2.tgz",
-			"integrity": "sha512-Bb33KbowVTIj5s7Ked1OsqHUeCpz//tPwR+E2zJgJKo9Z5XolZ9b6bdUgjmYlwnWhoOQKoTd1TYToZGn5mAYOg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"inherits": "^2.0.4",
-				"readable-stream": "^2.3.8",
-				"safe-buffer": "^5.2.1",
-				"to-buffer": "^1.2.1"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
 		"node_modules/robust-predicates": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
@@ -19329,32 +18650,6 @@
 			},
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/setimmediate": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-			"integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
-			"dev": true
-		},
-		"node_modules/sha.js": {
-			"version": "2.4.12",
-			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
-			"integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
-			"dev": true,
-			"dependencies": {
-				"inherits": "^2.0.4",
-				"safe-buffer": "^5.2.1",
-				"to-buffer": "^1.2.0"
-			},
-			"bin": {
-				"sha.js": "bin.js"
-			},
-			"engines": {
-				"node": ">= 0.10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/shebang-command": {
@@ -19766,56 +19061,6 @@
 			},
 			"engines": {
 				"node": ">= 0.4"
-			}
-		},
-		"node_modules/stream-browserify": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
-			"integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
-			"dev": true,
-			"dependencies": {
-				"inherits": "~2.0.4",
-				"readable-stream": "^3.5.0"
-			}
-		},
-		"node_modules/stream-browserify/node_modules/readable-stream": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-			"dev": true,
-			"dependencies": {
-				"inherits": "^2.0.3",
-				"string_decoder": "^1.1.1",
-				"util-deprecate": "^1.0.1"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
-		"node_modules/stream-http": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/stream-http/-/stream-http-3.2.0.tgz",
-			"integrity": "sha512-Oq1bLqisTyK3TSCXpPbT4sdeYNdmyZJv1LxpEm2vu1ZhK89kSE5YXwZc3cWk0MagGaKriBh9mCFbVGtO+vY29A==",
-			"dev": true,
-			"dependencies": {
-				"builtin-status-codes": "^3.0.0",
-				"inherits": "^2.0.4",
-				"readable-stream": "^3.6.0",
-				"xtend": "^4.0.2"
-			}
-		},
-		"node_modules/stream-http/node_modules/readable-stream": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-			"dev": true,
-			"dependencies": {
-				"inherits": "^2.0.3",
-				"string_decoder": "^1.1.1",
-				"util-deprecate": "^1.0.1"
-			},
-			"engines": {
-				"node": ">= 6"
 			}
 		},
 		"node_modules/stream-shift": {
@@ -20430,18 +19675,6 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/timers-browserify": {
-			"version": "2.0.12",
-			"resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.12.tgz",
-			"integrity": "sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==",
-			"dev": true,
-			"dependencies": {
-				"setimmediate": "^1.0.4"
-			},
-			"engines": {
-				"node": ">=0.6.0"
-			}
-		},
 		"node_modules/tinybench": {
 			"version": "2.9.0",
 			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -20517,26 +19750,6 @@
 			"engines": {
 				"node": ">=14.14"
 			}
-		},
-		"node_modules/to-buffer": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.1.tgz",
-			"integrity": "sha512-tB82LpAIWjhLYbqjx3X4zEeHN6M8CiuOEy2JY8SEQVdYRe3CCHOFaqrBW1doLDrfpWhplcW7BL+bO3/6S3pcDQ==",
-			"dev": true,
-			"dependencies": {
-				"isarray": "^2.0.5",
-				"safe-buffer": "^5.2.1",
-				"typed-array-buffer": "^1.0.3"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/to-buffer/node_modules/isarray": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-			"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-			"dev": true
 		},
 		"node_modules/to-regex-range": {
 			"version": "5.0.1",
@@ -20680,12 +19893,6 @@
 			"version": "2.8.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
-		},
-		"node_modules/tty-browserify": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
-			"integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==",
-			"dev": true
 		},
 		"node_modules/tunnel-agent": {
 			"version": "0.6.0",
@@ -21094,25 +20301,6 @@
 				"punycode": "^2.1.0"
 			}
 		},
-		"node_modules/url": {
-			"version": "0.11.4",
-			"resolved": "https://registry.npmjs.org/url/-/url-0.11.4.tgz",
-			"integrity": "sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==",
-			"dev": true,
-			"dependencies": {
-				"punycode": "^1.4.1",
-				"qs": "^6.12.3"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/url/node_modules/punycode": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-			"integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
-			"dev": true
-		},
 		"node_modules/use-callback-ref": {
 			"version": "1.3.3",
 			"resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
@@ -21184,19 +20372,6 @@
 			"integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
 			"peerDependencies": {
 				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-			}
-		},
-		"node_modules/util": {
-			"version": "0.12.5",
-			"resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
-			"integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
-			"dev": true,
-			"dependencies": {
-				"inherits": "^2.0.3",
-				"is-arguments": "^1.0.4",
-				"is-generator-function": "^1.0.7",
-				"is-typed-array": "^1.1.3",
-				"which-typed-array": "^1.1.2"
 			}
 		},
 		"node_modules/util-deprecate": {
@@ -21441,23 +20616,6 @@
 				"node": ">=14.14"
 			}
 		},
-		"node_modules/vite-plugin-node-polyfills": {
-			"version": "0.25.0",
-			"resolved": "https://registry.npmjs.org/vite-plugin-node-polyfills/-/vite-plugin-node-polyfills-0.25.0.tgz",
-			"integrity": "sha512-rHZ324W3LhfGPxWwQb2N048TThB6nVvnipsqBUJEzh3R9xeK9KI3si+GMQxCuAcpPJBVf0LpDtJ+beYzB3/chg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@rollup/plugin-inject": "^5.0.5",
-				"node-stdlib-browser": "^1.3.1"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/davidmyersdev"
-			},
-			"peerDependencies": {
-				"vite": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
-			}
-		},
 		"node_modules/vite-plugin-svgr": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/vite-plugin-svgr/-/vite-plugin-svgr-5.2.0.tgz",
@@ -21562,12 +20720,6 @@
 					"optional": false
 				}
 			}
-		},
-		"node_modules/vm-browserify": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
-			"integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
-			"dev": true
 		},
 		"node_modules/void-elements": {
 			"version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,6 @@
 		"vite-plugin-dts": "^4.5.4",
 		"vite-plugin-eslint2": "^5.0.5",
 		"vite-plugin-inspect": "^0.8.1",
-		"vite-plugin-node-polyfills": "^0.25.0",
 		"vite-plugin-svgr": "^5.2.0",
 		"vitest": "^4.1.8"
 	},


### PR DESCRIPTION
### Description

Removed `vite-plugin-node-polyfills` which was never imported or used anywhere in the codebase to resolve the `elliptic` CVE: https://github.com/aws-geospatial/amazon-location-features-demo-web/security/dependabot/138