### PR TITLE
restore type checks after Faker upgrade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,7 @@
 				"stylelint-config-standard": "^29.0.0",
 				"stylelint-order": "^5.0.0",
 				"stylelint-prettier": "^2.0.0",
-				"typescript": "^4.9.3",
+				"typescript": "^5.9.3",
 				"vite": "^6.4.2",
 				"vite-plugin-dts": "^4.5.4",
 				"vite-plugin-eslint2": "^5.0.5",
@@ -20930,16 +20930,17 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "4.9.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-			"integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+			"version": "5.9.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
 			},
 			"engines": {
-				"node": ">=4.2.0"
+				"node": ">=14.17"
 			}
 		},
 		"node_modules/typewise": {

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
 		"stylelint-config-standard": "^29.0.0",
 		"stylelint-order": "^5.0.0",
 		"stylelint-prettier": "^2.0.0",
-		"typescript": "^4.9.3",
+		"typescript": "^5.9.3",
 		"vite": "^6.4.2",
 		"vite-plugin-dts": "^4.5.4",
 		"vite-plugin-eslint2": "^5.0.5",

--- a/src/atomicui/molecules/Popup/Popup.test.tsx
+++ b/src/atomicui/molecules/Popup/Popup.test.tsx
@@ -68,7 +68,7 @@ describe("<Popup/>", () => {
 			<I18nextProvider i18n={i18n}>
 				<Popup
 					placeId={faker.lorem.word()}
-					position={[parseFloat(faker.location.longitude()), parseFloat(faker.location.latitude())]}
+					position={[faker.location.longitude(), faker.location.latitude()]}
 					label={`${faker.location.street()}, ${faker.location.city()}, ${faker.location.state()}, ${faker.location.zipCode()}`}
 					active
 					select={vi.fn()}

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -13,7 +13,7 @@ if (typeof window.URL.createObjectURL === "undefined") {
 }
 
 if (typeof window?.crypto?.randomUUID === "undefined") {
-	Object.assign(window, { crypto: { randomUUID: faker.datatype.uuid } });
+	Object.assign(window, { crypto: { randomUUID: () => faker.string.uuid() } });
 }
 
 if (typeof window?.matchMedia === "undefined") {

--- a/src/stores/createStore.ts
+++ b/src/stores/createStore.ts
@@ -21,7 +21,6 @@ const createStore = <T>(
 		return init;
 	};
 
-	/* @ts-expect-error: valid params */
 	const createDataStore = persistant ? persist(createState, { name: localStorageKey }) : createState;
 	/* @ts-expect-error: valid params */
 	return create<T & BaseStateProps>(devtools(createDataStore));


### PR DESCRIPTION
Upgraded typescript version to support new faker library introduced in https://github.com/aws-geospatial/amazon-location-features-demo-web/pull/460
