### PR TITLE
chore: override vulnerable uuid versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9542,14 +9542,6 @@
 				"uuid": "^8.3.2"
 			}
 		},
-		"node_modules/aws-iot-device-sdk-v2/node_modules/uuid": {
-			"version": "8.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-			"bin": {
-				"uuid": "dist/bin/uuid"
-			}
-		},
 		"node_modules/aws-sign2": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -16667,15 +16659,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
-		},
-		"node_modules/mochawesome/node_modules/uuid": {
-			"version": "8.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-			"dev": true,
-			"bin": {
-				"uuid": "dist/bin/uuid"
 			}
 		},
 		"node_modules/mqtt": {

--- a/package.json
+++ b/package.json
@@ -127,7 +127,8 @@
 		"semver": "^5.7.2",
 		"trim-newlines": "^3.0.1",
 		"underscore": "^1.12.1",
-		"underscore.string": "^3.3.5"
+		"underscore.string": "^3.3.5",
+		"uuid": "11.1.1"
 	},
 	"jest": {
 		"moduleNameMapper": {


### PR DESCRIPTION
## Summary
- replaces vulnerable nested UUID 8.3.2 copies with UUID 11.1.1 through a scoped override
- fixes one saved Dependabot alert row
- intentionally defers the MapLibre and Elliptic upgrades

## Validation
- all 76 unit tests passed
- this replacement PR uses an in-repository branch so E2E can access the required Actions secrets

Supersedes #469.